### PR TITLE
LPNU: [feat] ignore non-alphanumeric characters in search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+[2.1.1] - 2023-08-11
+- Make searchbar ignore non-alphanumeric characters (e.g. if `ПЗ22` gets searched, `ПЗ-22` will match even though there's no '-').
+- Minor refactor for `VirtualizedDataList`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timetable",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "homepage": "/",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## 📝 Implementation details & Description
- Make search bar ignore non-alphanumeric characters (e.g. if `ПЗ22` gets searched, `ПЗ-22` will match even though there's no '-').
- Create `CHANGELOG.md`.
- Update version to `2.1.1`.