### PR TITLE
[feat] add purpose attribute for favicon in manifest.json

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,8 +5,9 @@
     {
       "src": "images/favicon.png",
       "sizes": "200x200",
-      "type": "image/png"
-    }    
+      "type": "image/png",
+      "purpose": "maskable"
+    }
   ],
   "start_url": ".",
   "display": "standalone",


### PR DESCRIPTION
Add a purpose attribute to the favicon entry in the manifest.json to support maskable icons.