### PR TITLE
Clarify timetable view switching with a compact title selector

### DIFF
--- a/src/features/header/HeaderPanel.module.scss
+++ b/src/features/header/HeaderPanel.module.scss
@@ -21,7 +21,6 @@
     align-items: center;
     flex-wrap: wrap;
     justify-content: center;
-
     svg {
       width: clamp(2rem, 8vw, 2.75rem);
       height: clamp(2rem, 8vw, 2.75rem);
@@ -30,75 +29,4 @@
     }
   }
 
-  button.exams {
-    display: inline-block;
-    padding: .25rem .5rem;
-    border-radius: $border-radius;
-    font-size: 1rem;
-    line-height: 1.2;
-    color: hsla(0, 0%, 100%, .6);
-    white-space: nowrap;
-    cursor: pointer;
-    transition: color .2s ease-in-out, background-color .2s ease-in-out;
-    svg {
-      display: inline-block;
-      width: 1.125rem;
-      height: 1.125rem;
-      vertical-align: -.2em;
-      margin-right: .4rem;
-    }
-    .arrow {
-      width: .95rem;
-      height: .95rem;
-      margin-left: .125rem;
-      margin-right: 0;
-      vertical-align: -.125em;
-      opacity: .7;
-      transition: transform .2s ease-in-out;
-    }
-    .exam-icon {
-      @include mobile {
-        display: none;
-      }
-    }
-    &.published {
-      color: var(--text-clr);
-      &::before {
-        content: '';
-        display: inline-block;
-        width: .45rem;
-        height: .45rem;
-        margin-right: .625rem;
-        border-radius: 50%;
-        vertical-align: .1em;
-        background-color: hsla(0, 0%, 78%, 1);
-        box-shadow: 0 0 0 3px hsla(0, 0%, 69%, 0.3);
-      }
-    }
-    &.back {
-      padding: .25rem .625rem .25rem .5rem;
-      color: $extra-text-clr;
-      .arrow {
-        margin-left: 0;
-        margin-right: .4rem;
-        transform: scaleX(-1);
-      }
-    }
-    @include can-hover {
-      &:hover {
-        color: var(--text-clr);
-        background-color: var(--accent-clr);
-        .arrow {
-          transform: translateX(2px);
-        }
-        &.back .arrow {
-          transform: scaleX(-1) translateX(2px);
-        }
-      }
-    }
-    &:focus-visible {
-      color: var(--text-clr);
-      background-color: var(--accent-clr);
-    }
-  }
 }

--- a/src/features/header/TimetableHeader.module.scss
+++ b/src/features/header/TimetableHeader.module.scss
@@ -21,37 +21,23 @@ header.header {
   }
 }
 
-.actions {
+.title-group {
   display: flex;
   align-items: center;
-  margin-left: auto;
+  gap: .375rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .title {
-  display: inline-flex;
-  align-items: baseline;
-  gap: .375em;
+  min-width: 0;
+  overflow-wrap: anywhere;
   font-size: clamp(1rem, 8vw, 2rem);
   font-weight: $semi-bold-font;
   line-height: 1.2;
   color: var(--text-clr);
   text-align: center;
   @include mobile {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0;
     line-height: 1.1;
-  }
-}
-
-.mode {
-  font-size: .6em;
-  font-weight: $thin-font;
-  color: $extra-text-clr;
-  white-space: nowrap;
-  @include mobile {
-    font-size: .5em;
-    font-weight: $regular-font;
-    line-height: 1.2;
   }
 }

--- a/src/features/header/TimetableHeader.tsx
+++ b/src/features/header/TimetableHeader.tsx
@@ -1,10 +1,7 @@
 import type React from "react";
 import type { FC } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import ArrowRightIcon from "@/assets/ArrowRightIcon";
-import ExamIcon from "@/assets/ExamIcon";
 import HomeIcon from "@/assets/HomeIcon";
-import useExamsPublished from "@/hooks/useExamsPublished";
 import usePageTitle from "@/hooks/usePageTitle";
 import { useIsMobile } from "@/hooks/useWindowDimensions";
 import Toggle from "@/shared/Toggle";
@@ -16,6 +13,7 @@ import Toast from "@/utils/toasts";
 import WeekNavigation from "../timetable/ui/WeekNavigation";
 import SavedMenu from "./components/SavedMenu";
 import TimetablePartials from "./components/TimetablePartials";
+import TimetableViewSelect from "./components/TimetableViewSelect";
 import generalStyles from "./HeaderPanel.module.scss";
 import styles from "./TimetableHeader.module.scss";
 
@@ -51,7 +49,6 @@ const TimetableHeader: FC<OwnProps> = ({
   const navigate = useNavigate();
   const group = useParams().group?.trim() ?? "";
   const isMobile = useIsMobile();
-  const examsPublished = useExamsPublished();
   const groupTitle = timetableType === "merged" ? "Мій розклад" : group;
   usePageTitle(groupTitle);
 
@@ -91,10 +88,12 @@ const TimetableHeader: FC<OwnProps> = ({
           </Link>
           <SavedMenu timetableChanged={loading} />
         </div>
-        <h1 className={styles.title}>
-          {groupTitle}
-          {isExamsTimetable && <span className={styles.mode}>Екзамени</span>}
-        </h1>
+        <div className={styles["title-group"]}>
+          <h1 className={styles.title}>{groupTitle}</h1>
+          {timetableType !== "selective" && timetableType !== "parttime" && (
+            <TimetableViewSelect isExams={isExamsTimetable} onChange={handleIsExamsTimetableChange} />
+          )}
+        </div>
       </nav>
       {!isExamsTimetable && (
         <span className={styles.controls}>
@@ -115,41 +114,6 @@ const TimetableHeader: FC<OwnProps> = ({
             </>
           )}
           <TimetablePartials partials={partials} handlePartialClick={updatePartialTimetable} />
-        </span>
-      )}
-      {timetableType !== "selective" && timetableType !== "parttime" && (
-        <span className={styles.actions}>
-          <button
-            type="button"
-            className={classes(
-              generalStyles.exams,
-              isExamsTimetable && generalStyles.back,
-              !isExamsTimetable && examsPublished && generalStyles.published
-            )}
-            title={
-              isExamsTimetable
-                ? "Повернутися до розкладу пар"
-                : examsPublished
-                  ? "Відкрити розклад екзаменів"
-                  : "Відкрити розклад екзаменів (можливо, ще не опублікований)"
-            }
-            onClick={() => {
-              handleIsExamsTimetableChange(!isExamsTimetable);
-            }}
-          >
-            {isExamsTimetable ? (
-              <>
-                <ArrowRightIcon className={generalStyles.arrow} />
-                {isMobile ? "Пари" : "Розклад пар"}
-              </>
-            ) : (
-              <>
-                <ExamIcon className={generalStyles["exam-icon"]} />
-                {isMobile ? "Екзамени" : "Розклад екзаменів"}
-                <ArrowRightIcon className={generalStyles.arrow} />
-              </>
-            )}
-          </button>
         </span>
       )}
     </header>

--- a/src/features/header/components/TimetableViewSelect.module.scss
+++ b/src/features/header/components/TimetableViewSelect.module.scss
@@ -1,0 +1,105 @@
+.select {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+  position: relative;
+  flex-shrink: 0;
+  color: var(--text-clr);
+}
+
+.trigger {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  min-height: 2.125rem;
+  padding: .25rem .5rem;
+  border: 1px solid var(--border-clr);
+  background: var(--accent-clr);
+  border-radius: .5rem;
+  font-size: .9375rem;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover,
+  &[aria-expanded='true'] {
+    background: rgb(255 255 255 / .25);
+  }
+}
+
+.trigger:focus-visible,
+.option:focus-visible {
+  outline: 2px solid var(--text-clr);
+  outline-offset: 2px;
+}
+
+.chevron {
+  width: .375rem;
+  height: .375rem;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: translateY(-.125rem) rotate(45deg);
+  opacity: .75;
+
+  [aria-expanded='true'] & {
+    transform: translateY(.125rem) rotate(225deg);
+  }
+}
+
+.menu {
+  display: grid;
+  gap: .25rem;
+  position: absolute;
+  top: calc(100% + .375rem);
+  right: 0;
+  z-index: 110;
+  width: 10rem;
+  padding: .375rem;
+  border: 1px solid var(--border-clr);
+  border-radius: .75rem;
+  background: #153b49;
+  box-shadow: 0 .5rem 1.5rem rgb(0 0 0 / .25);
+
+  :global(.dark-mode) & {
+    background: #171c26;
+  }
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+  min-height: 2.25rem;
+  padding: .375rem .625rem;
+  border-radius: .375rem;
+  text-align: left;
+  font-size: .9375rem;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible,
+  &[aria-checked='true'] {
+    background: var(--accent-clr);
+  }
+}
+
+.check {
+  width: .875rem;
+  height: .875rem;
+  display: flex;
+  align-items: center;
+}
+
+.select .menu .check > svg {
+  width: .875rem;
+  height: .875rem;
+}
+
+@media (pointer: coarse) {
+  .trigger,
+  .option {
+    min-height: 44px;
+  }
+}

--- a/src/features/header/components/TimetableViewSelect.tsx
+++ b/src/features/header/components/TimetableViewSelect.tsx
@@ -1,0 +1,100 @@
+import { type KeyboardEvent, useEffect, useId, useRef, useState } from "react";
+import CheckMarkIcon from "@/assets/CheckMarkIcon";
+import styles from "./TimetableViewSelect.module.scss";
+
+type Props = {
+  isExams: boolean;
+  onChange: (isExams: boolean) => void;
+};
+
+export default function TimetableViewSelect({ isExams, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const menuId = useId();
+  const container = useRef<HTMLFieldSetElement>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
+  const classesOption = useRef<HTMLButtonElement>(null);
+  const examsOption = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    (isExams ? examsOption : classesOption).current?.focus();
+    const dismiss = (event: PointerEvent) => {
+      if (event.target instanceof Node && !container.current?.contains(event.target)) setOpen(false);
+    };
+    document.addEventListener("pointerdown", dismiss);
+    return () => document.removeEventListener("pointerdown", dismiss);
+  }, [open, isExams]);
+
+  const close = () => {
+    setOpen(false);
+    trigger.current?.focus();
+  };
+
+  const navigateOptions = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      close();
+    } else if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      (event.currentTarget === classesOption.current ? examsOption : classesOption).current?.focus();
+    } else if (event.key === "Home" || event.key === "End") {
+      event.preventDefault();
+      (event.key === "Home" ? classesOption : examsOption).current?.focus();
+    }
+  };
+
+  return (
+    <fieldset
+      aria-label="Вибір типу розкладу"
+      ref={container}
+      className={styles.select}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) setOpen(false);
+      }}
+    >
+      <button
+        ref={trigger}
+        type="button"
+        className={styles.trigger}
+        aria-label={`Тип розкладу: ${isExams ? "Екзамени" : "Пари"}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        onClick={() => setOpen(!open)}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            setOpen(true);
+          } else if (event.key === "Escape") close();
+        }}
+      >
+        {isExams ? "Екзамени" : "Пари"}
+        <span className={styles.chevron} aria-hidden="true" />
+      </button>
+      {open && (
+        <div id={menuId} role="menu" aria-label="Тип розкладу" className={styles.menu}>
+          {[false, true].map((exams) => (
+            <button
+              key={String(exams)}
+              ref={exams ? examsOption : classesOption}
+              type="button"
+              role="menuitemradio"
+              aria-checked={isExams === exams}
+              className={styles.option}
+              onKeyDown={navigateOptions}
+              onClick={() => {
+                close();
+                if (isExams !== exams) onChange(exams);
+              }}
+            >
+              {exams ? "Екзамени" : "Пари"}
+              <span className={styles.check} aria-hidden="true">
+                {isExams === exams && <CheckMarkIcon />}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </fieldset>
+  );
+}


### PR DESCRIPTION
Replace the ambiguous exams button with a styled selector beside the group title.

Show the current view, a persistent border, spaced options, and an active checkmark. Support keyboard navigation and outside-click dismissal.

<img width="390" height="97" alt="image" src="https://github.com/user-attachments/assets/0ad24223-81f5-4b4d-96d6-f21edfd8c559" />

<img width="434" height="86" alt="image" src="https://github.com/user-attachments/assets/e7dc749e-75e5-4e42-b87c-ec8da305d494" />



Validation: production build and targeted lint pass; switching and mobile layout checked using the temporary preview.